### PR TITLE
changed argument to .remove_child

### DIFF
--- a/sepp/tree.py
+++ b/sepp/tree.py
@@ -184,7 +184,7 @@ class PhylogeneticTree(object):
         n = self.n_leaves
         potentially_deleted_nd = e.tail_node
         grandparent_nd = potentially_deleted_nd.parent_node
-        e.tail_node.remove_child(nr, suppress_unifurcations=True)
+        e.tail_node.remove_child(nr, suppress_deg_two=True)
 
         nr.edge.length = None
         nr.parent_node = None


### PR DESCRIPTION
In `Dendropy4` the function `remove_child` apparently takes `suppress_deg_two` instead `suppress_unifurcations`.